### PR TITLE
TPU support

### DIFF
--- a/build_vocab.py
+++ b/build_vocab.py
@@ -14,17 +14,21 @@ if __name__ == "__main__":
     vocab = set()
     dataset = read_dataset(args.data, args.num_channels)
     read_op = dataset.make_one_shot_iterator().get_next()
+    max_frames = max_symbols = 0
     with tf.Session() as sess:
         handle = tqdm(None, unit='phrase')
         while True:
             try:
-                _, label = sess.run(read_op)
+                features, label = sess.run(read_op)
+                max_frames = max([max_frames, features.shape[0]])
+                max_symbols = max([max_symbols, len(label)])
                 for x in label:
                     vocab.add(x.decode('utf-8'))
                 handle.update()
             except tf.errors.OutOfRangeError:
                 break
     handle.close()
+    print('Max frames: {}, max symbols: {}'.format(max_frames, max_symbols))
     if args.output is None:
         print('\n'.join(x for x in vocab))
     else:

--- a/las/model.py
+++ b/las/model.py
@@ -5,7 +5,7 @@ from tensorflow.python.util import nest
 
 from las.ops import lstm_cell
 from las.ops import pyramidal_bilstm
-from utils import TrainingSigmoidHelper, ScheduledSigmoidHelper, DenseBinfDecoder
+from utils import TrainingSigmoidHelper, ScheduledSigmoidHelper, DenseBinfDecoder, TPUScheduledEmbeddingTrainingHelper
 
 __all__ = [
     'listener',
@@ -271,7 +271,7 @@ def speller(encoder_outputs,
                 helper = ScheduledSigmoidHelper(decoder_inputs, target_sequence_length,
                     embedding_fn, hparams.sampling_probability, binf_to_ipa=binf_embedding)
             else:
-                helper = tf_contrib.seq2seq.ScheduledEmbeddingTrainingHelper(
+                helper = TPUScheduledEmbeddingTrainingHelper(
                     decoder_inputs, target_sequence_length,
                     embedding_fn, hparams.sampling_probability)
         else:

--- a/las/model.py
+++ b/las/model.py
@@ -257,7 +257,7 @@ def speller(encoder_outputs,
     else:
         initial_state = decoder_cell.zero_state(batch_size, tf.float32)
 
-    maximum_iterations = None
+    maximum_iterations = hparams.max_symbols if hparams.max_symbols > 0 else None
     if mode != tf.estimator.ModeKeys.TRAIN:
         max_source_length = tf.reduce_max(source_sequence_length)
         maximum_iterations = tf.to_int32(tf.round(tf.to_float(

--- a/model_helper.py
+++ b/model_helper.py
@@ -251,7 +251,6 @@ def las_model_fn(features,
 
         return tf.estimator.EstimatorSpec(mode, predictions=predictions)
 
-    metrics = None
     edit_distance, edit_distance_binf = None, None
     with tf.name_scope('metrics'):
         if sample_ids_phones is not None:

--- a/model_helper.py
+++ b/model_helper.py
@@ -348,6 +348,8 @@ def las_model_fn(features,
 
     with tf.name_scope('train'):
         optimizer = tf.train.AdamOptimizer(params.learning_rate)
+        if params.tpu_name and params.tpu_name != 'fake':
+            optimizer = tf.tpu.CrossShardOptimizer(optimizer)
         var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
         total_params = np.sum([np.prod(x.shape.as_list()) for x in var_list])
         tf.logging.info('Trainable parameters: {}'.format(total_params))

--- a/model_helper.py
+++ b/model_helper.py
@@ -388,5 +388,5 @@ def las_model_fn(features,
     if not params.tpu_name:
         return tf.estimator.EstimatorSpec(mode, loss=loss, train_op=train_op, training_hooks=[logging_hook])
     else:
-        return tf.estimator.tpu.TPUEstimatorSpec(mode, loss=loss, train_op=train_op, training_hooks=[logging_hook])
+        return tf.estimator.tpu.TPUEstimatorSpec(mode, loss=loss, train_op=train_op)
 

--- a/model_helper.py
+++ b/model_helper.py
@@ -385,5 +385,8 @@ def las_model_fn(features,
         train_log_data['ctc_edit_distance'] = tf.reduce_mean(ctc_edit_distance)
     logging_hook = tf.train.LoggingTensorHook(train_log_data, every_n_iter=10)
 
-    return tf.estimator.EstimatorSpec(mode, loss=loss, train_op=train_op, training_hooks=[logging_hook])
+    if not params.tpu_name:
+        return tf.estimator.EstimatorSpec(mode, loss=loss, train_op=train_op, training_hooks=[logging_hook])
+    else:
+        return tf.estimator.tpu.TPUEstimatorSpec(mode, loss=loss, train_op=train_op, training_hooks=[logging_hook])
 

--- a/model_helper.py
+++ b/model_helper.py
@@ -268,7 +268,7 @@ def las_model_fn(features,
     # To prevent this, we use last batch average in case of TRAIN.
     if mode != tf.estimator.ModeKeys.TRAIN:
         tf.summary.scalar('edit_distance', metrics['edit_distance'][1])
-    else:
+    elif not params.tpu_name:
         tf.summary.scalar('edit_distance', tf.reduce_mean(edit_distance if edit_distance is not None else edit_distance_binf))
 
     audio_loss_ipa, audio_loss_binf = None, None

--- a/train.py
+++ b/train.py
@@ -192,7 +192,9 @@ def main(args):
             input_fn=lambda params: input_fn(
                 args.train, args.vocab, args.norm, num_channels=args.num_channels,
                 batch_size=params.batch_size,
-                num_epochs=args.num_epochs, binf2phone=None, num_parallel_calls=args.num_parallel_calls))
+                num_epochs=args.num_epochs, binf2phone=None, num_parallel_calls=args.num_parallel_calls),
+            steps=args.num_epochs * 1000 * hparams.batch_size
+        )
 
 
 if __name__ == '__main__':

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -35,7 +35,7 @@ def read_dataset(filename, num_channels=39, labels_shape=[], labels_dtype=tf.str
 
 def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
     batch_size=8, num_epochs=1, num_parallel_calls=32, is_infer=False,
-    binary_targets=False, labels_shape=[]):
+    binary_targets=False, labels_shape=[], max_frames=-1, max_symbols=-1):
 
     try:
         use_labels = len(dataset.output_classes) == 2
@@ -64,6 +64,11 @@ def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
             drop_remainder=True)
     else:
         output_buffer_size = batch_size * 1000
+
+        if max_frames > 0:
+            dataset = dataset.filter(
+                lambda inputs, labels: tf.logical_and(tf.shape(inputs)[0] <= max_frames,
+                                                      tf.shape(labels)[0] <= max_symbols))
 
         if not binary_targets:
             sos_id = tf.cast(vocab_table.lookup(tf.constant(sos)), tf.int32)
@@ -132,9 +137,23 @@ def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
                     'target_sequence_length': target_sequence_length
                 }))
 
+        if max_frames > 0:
+            padded_shapes = (
+                {
+                    'encoder_inputs': tf.TensorShape([max_frames, dataset.output_shapes[0]['encoder_inputs'][1].value]),
+                    'source_sequence_length': dataset.output_shapes[0]['source_sequence_length']
+                },
+                {
+                    'targets_inputs': tf.TensorShape([max_symbols]),
+                    'targets_outputs': tf.TensorShape([max_symbols]),
+                    'target_sequence_length': dataset.output_shapes[1]['target_sequence_length'],
+                }
+            )
+        else:
+            padded_shapes = dataset.output_shapes
         dataset = dataset.padded_batch(
             batch_size,
-            padded_shapes=dataset.output_shapes,
+            padded_shapes=padded_shapes,
             padding_values=(
                 {
                     'encoder_inputs': 0.0,

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -74,7 +74,7 @@ def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
             sos_id = tf.cast(vocab_table.lookup(tf.constant(sos)), tf.int32)
             eos_id = tf.cast(vocab_table.lookup(tf.constant(eos)), tf.int32)
 
-        dataset = dataset.repeat(num_epochs)
+        dataset = dataset.repeat(num_epochs if num_epochs > 0 else None)
 
         if not is_infer:
             dataset = dataset.shuffle(output_buffer_size)
@@ -164,6 +164,6 @@ def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
                     'targets_outputs': 0 if binary_targets else eos_id,
                     'target_sequence_length': 0,
                 }),
-        drop_remainder=True)
+            drop_remainder=True)
 
     return dataset

--- a/utils/features_utils.py
+++ b/utils/features_utils.py
@@ -21,5 +21,6 @@ def calculate_mfcc_op(sample_rate, coeffs, window, step, mels):
 
 
 def load_normalization(norm_path):
-    means, stds = joblib.load(norm_path)
+    with tf.gfile.Open(norm_path, 'rb') as f:
+        means, stds = joblib.load(f)
     return means, stds

--- a/utils/params_utils.py
+++ b/utils/params_utils.py
@@ -34,6 +34,7 @@ def get_default_hparams():
         add_noise=0,
         noise_std=0.1,
         ctc_weight=-1.,
+        tpu_name='',
 
         # encoder setting
         encoder_layers=3,
@@ -111,6 +112,7 @@ def create_hparams(args, target_vocab_size=None, binf_count=None, sos_id=1, eos_
 def get_encoder_decoder_hparams(hparams):
     learning_rate = hparams.pop_hparam('learning_rate')
     ctc_weight = hparams.pop_hparam('ctc_weight')
+    tpu_name = hparams.pop_hparam('tpu_name')
     dropout = hparams.pop_hparam('dropout')
     l2_reg_scale = hparams.pop_hparam('l2_reg_scale')
     add_noise = hparams.pop_hparam('add_noise')
@@ -147,5 +149,6 @@ def get_encoder_decoder_hparams(hparams):
         add_noise=add_noise,
         noise_std=noise_std,
         ctc_weight=ctc_weight,
+        tpu_name=tpu_name,
         encoder=encoder_hparams,
         decoder=decoder_hparams)

--- a/utils/params_utils.py
+++ b/utils/params_utils.py
@@ -141,6 +141,7 @@ def get_encoder_decoder_hparams(hparams):
         binary_outputs=binary_outputs,
         binf_sampling=binf_sampling,
         binf_projection=binf_projection,
+        max_symbols=max_symbols,
         multitask=multitask)
 
     for name, value in hparams.values().items():

--- a/utils/params_utils.py
+++ b/utils/params_utils.py
@@ -35,6 +35,8 @@ def get_default_hparams():
         noise_std=0.1,
         ctc_weight=-1.,
         tpu_name='',
+        max_frames=-1,
+        max_symbols=-1,
 
         # encoder setting
         encoder_layers=3,
@@ -113,6 +115,8 @@ def get_encoder_decoder_hparams(hparams):
     learning_rate = hparams.pop_hparam('learning_rate')
     ctc_weight = hparams.pop_hparam('ctc_weight')
     tpu_name = hparams.pop_hparam('tpu_name')
+    max_frames = hparams.pop_hparam('max_frames')
+    max_symbols = hparams.pop_hparam('max_symbols')
     dropout = hparams.pop_hparam('dropout')
     l2_reg_scale = hparams.pop_hparam('l2_reg_scale')
     add_noise = hparams.pop_hparam('add_noise')
@@ -150,5 +154,7 @@ def get_encoder_decoder_hparams(hparams):
         noise_std=noise_std,
         ctc_weight=ctc_weight,
         tpu_name=tpu_name,
+        max_frames=max_frames,
+        max_symbols=max_symbols,
         encoder=encoder_hparams,
         decoder=decoder_hparams)

--- a/utils/training_helper.py
+++ b/utils/training_helper.py
@@ -75,7 +75,7 @@ class TPUScheduledEmbeddingTrainingHelper(tf_contrib.seq2seq.ScheduledEmbeddingT
             return finished, next_inputs, state
 
 
-class ScheduledSigmoidHelper(tf_contrib.seq2seq.ScheduledEmbeddingTrainingHelper):
+class ScheduledSigmoidHelper(TPUScheduledEmbeddingTrainingHelper):
     def __init__(self, inputs, sequence_length, embedding, sampling_probability,
                  time_major=False, seed=None, scheduling_seed=None, name=None,
                  binf_to_ipa=None):

--- a/utils/vocab_utils.py
+++ b/utils/vocab_utils.py
@@ -23,11 +23,11 @@ EOS_ID = 2
 
 def load_vocab(filename):
     if not '.pickle' in filename:
-        with open(filename, 'r') as f:
+        with tf.gfile.Open(filename, 'r') as f:
             vocab_list = [vocab.strip('\r\n') for vocab in f]
             vocab_list = [UNK, SOS, EOS] + vocab_list
     else:
-        with open(filename, 'rb') as f:
+        with tf.gfile.Open(filename, 'rb') as f:
             vocab_list = pickle.load(f)
             vocab_list = [UNK, SOS, EOS] + vocab_list
 


### PR DESCRIPTION
Adds TPU training support. Works well with scheduled sampling. One of the problems is that validation is not working when training on TPU. You have to run `eval.py` manually.

Also it is super important to carefully select hyperparameters. Batch size of 8 might give you OOM, while batch size 128 would work well with everything else being the same.

Speed of 6.5M 256/3 model on TPUv2 is around 450 examples/sec. That's roughly 20 times speedup over 1080 GPU.

Important parameters added are `max_frames` and `max_symbols`. They can be calculated from TF-record using `build_vocab.py`. For Timit `--max_frames 780 --max_symbols 80` works well for 10ms features step.