### PR TITLE
Feature/t2t support and trainable binf

### DIFF
--- a/build_vocab.py
+++ b/build_vocab.py
@@ -2,7 +2,7 @@ import argparse
 import tensorflow as tf
 from tqdm import tqdm
 
-from utils.dataset_utils import read_dataset
+from utils.dataset_utils import read_dataset, read_dataset_t2t_format
 
 
 if __name__ == "__main__":
@@ -10,27 +10,38 @@ if __name__ == "__main__":
     parser.add_argument('--data', type=str, required=True)
     parser.add_argument('--num_channels', type=int, required=True)
     parser.add_argument('--output', type=str, default=None)
+    parser.add_argument('--t2t_format', action='store_true')
     args = parser.parse_args()
     vocab = set()
-    dataset = read_dataset(args.data, args.num_channels)
+    if args.t2t_format:
+        dataset = read_dataset_t2t_format(args.data, 1, tf.estimator.ModeKeys.TRAIN, -1, -1)
+    else:
+        dataset = read_dataset(args.data, args.num_channels)
     read_op = dataset.make_one_shot_iterator().get_next()
     max_frames = max_symbols = 0
     with tf.Session() as sess:
         handle = tqdm(None, unit='phrase')
         while True:
             try:
-                features, label = sess.run(read_op)
+                if args.t2t_format:
+                    item = sess.run(read_op)
+                    features, labels = item['inputs'], item['targets']
+                    max_symbols = max([max_symbols, labels.shape[0]])
+                else:
+                    features, label = sess.run(read_op)
+                    max_symbols = max([max_symbols, len(label)])
                 max_frames = max([max_frames, features.shape[0]])
-                max_symbols = max([max_symbols, len(label)])
-                for x in label:
-                    vocab.add(x.decode('utf-8'))
+                if not args.t2t_format:
+                    for x in label:
+                        vocab.add(x.decode('utf-8'))
                 handle.update()
             except tf.errors.OutOfRangeError:
                 break
     handle.close()
     print('Max frames: {}, max symbols: {}'.format(max_frames, max_symbols))
-    if args.output is None:
-        print('\n'.join(x for x in vocab))
-    else:
-        with open(args.output, 'w') as f:
-            f.write('\n'.join(x for x in vocab))
+    if not args.t2t_format:
+        if args.output is None:
+            print('\n'.join(x for x in vocab))
+        else:
+            with open(args.output, 'w') as f:
+                f.write('\n'.join(x for x in vocab))

--- a/eval.py
+++ b/eval.py
@@ -31,31 +31,6 @@ def parse_args():
 
     return parser.parse_args()
 
-
-def input_fn(dataset_filename, vocab_filename, norm_filename=None, num_channels=39, batch_size=8, take=0,
-    binf2phone=None):
-    binary_targets = binf2phone is not None
-    labels_shape = [] if not binary_targets else len(binf2phone.index)
-    labels_dtype = tf.string if not binary_targets else tf.float32
-    dataset = utils.read_dataset(dataset_filename, num_channels, labels_shape=labels_shape,
-        labels_dtype=labels_dtype)
-    vocab_table = utils.create_vocab_table(vocab_filename)
-
-    if norm_filename is not None:
-        means, stds = utils.load_normalization(args.norm)
-    else:
-        means = stds = None
-
-    sos = binf2phone[utils.SOS].values if binary_targets else utils.SOS
-    eos = binf2phone[utils.EOS].values if binary_targets else utils.EOS
-
-    dataset = utils.process_dataset(
-        dataset, vocab_table, sos, eos, means, stds, batch_size, 1,
-        binary_targets=binary_targets, labels_shape=labels_shape)
-
-    return dataset
-
-
 def main(args):
     eval_name = str(os.path.basename(args.data).split('.')[0])
     config = tf.estimator.RunConfig(model_dir=args.model_dir)
@@ -79,9 +54,9 @@ def main(args):
         params=hparams)
 
     tf.logging.info('Evaluating on {}'.format(eval_name))
-    model.evaluate(lambda: input_fn(
+    model.evaluate(lambda: utils.input_fn(
             args.data, args.vocab, args.norm, num_channels=args.num_channels,
-            batch_size=args.batch_size, binf2phone=None), name=eval_name)
+            batch_size=args.batch_size), name=eval_name)
 
 
 if __name__ == '__main__':

--- a/eval.py
+++ b/eval.py
@@ -19,6 +19,8 @@ def parse_args():
                         help='normalization params')
     parser.add_argument('--t2t_format', action='store_true',
                         help='Use dataset in the format of ASR problems of Tensor2Tensor framework. --train param should be directory')
+    parser.add_argument('--t2t_problem_name', type=str,
+                        help='Problem name for data in T2T format.')
     parser.add_argument('--mapping', type=str,
                         help='additional mapping when evaluation')
     parser.add_argument('--model_dir', type=str, required=True,
@@ -60,7 +62,7 @@ def main(args):
     if args.t2t_format:
         input_fn = lambda: utils.input_fn_t2t(
             args.data, tf.estimator.ModeKeys.EVAL, hparams,
-            batch_size=args.batch_size)
+            args.t2t_problem_name, batch_size=args.batch_size)
     else:
         input_fn = lambda: utils.input_fn(
             args.data, args.vocab, args.norm, num_channels=args.num_channels,

--- a/infer.py
+++ b/infer.py
@@ -62,33 +62,6 @@ def parse_args():
 
     return parser.parse_args()
 
-
-def input_fn(dataset_filename, vocab_filename, norm_filename=None, num_channels=39, batch_size=8, take=0,
-    binf2phone=None):
-    binary_targets = binf2phone is not None
-    labels_shape = [] if not binary_targets else len(binf2phone.index)
-    labels_dtype = tf.string if not binary_targets else tf.float32
-    dataset = utils.read_dataset(dataset_filename, num_channels, labels_shape=labels_shape,
-        labels_dtype=labels_dtype)
-    vocab_table = utils.create_vocab_table(vocab_filename)
-
-    if norm_filename is not None:
-        means, stds = utils.load_normalization(args.norm)
-    else:
-        means = stds = None
-
-    sos = binf2phone[utils.SOS].values if binary_targets else utils.SOS
-    eos = binf2phone[utils.EOS].values if binary_targets else utils.EOS
-
-    dataset = utils.process_dataset(
-        dataset, vocab_table, sos, eos, means, stds, batch_size, 1,
-        binary_targets=binary_targets, labels_shape=labels_shape, is_infer=True)
-
-    if args.take > 0:
-        dataset = dataset.take(take)
-    return dataset
-
-
 def to_text(vocab_list, sample_ids):
     sym_list = [vocab_list[x] for x in sample_ids] + [utils.EOS]
     return args.delimiter.join(sym_list[:sym_list.index(utils.EOS)])
@@ -254,7 +227,7 @@ def main(args):
     predictions = model.predict(
         input_fn=lambda: input_fn(
             args.data, args.vocab, args.norm, num_channels=args.num_channels, batch_size=args.batch_size,
-            take=args.take, binf2phone=None),
+            take=args.take, is_infer=True),
         predict_keys=predict_keys)
 
     if args.calc_frame_binf_accuracy:

--- a/infer.py
+++ b/infer.py
@@ -225,7 +225,7 @@ def main(args):
         predict_keys.append('logits_binf')
         predict_keys.append('alignment_binf')
     predictions = model.predict(
-        input_fn=lambda: input_fn(
+        input_fn=lambda: utils.input_fn(
             args.data, args.vocab, args.norm, num_channels=args.num_channels, batch_size=args.batch_size,
             take=args.take, is_infer=True),
         predict_keys=predict_keys)

--- a/model_helper.py
+++ b/model_helper.py
@@ -341,7 +341,7 @@ def las_model_fn(features,
         hooks = [eval_summary_hook]
         if binf_embedding is not None:
             with tf.name_scope('binf_image'):
-                binf_image = tf.tile(binf_embedding[None, :, :, None], [tf.shape(encoder_inputs)[0], 1, 1, 1])
+                binf_image = binf_embedding[None, :, :, None]
             binf_summary = tf.summary.image('binf_image', binf_image)
             binf_hook = tf.train.SummarySaverHook(
                 save_steps=20,

--- a/train.py
+++ b/train.py
@@ -174,7 +174,7 @@ def main(args):
                 args.vocab, args.norm, num_channels=args.num_channels,
                 batch_size=params.batch_size if 'batch_size' in params else args.batch_size,
                 num_epochs=args.num_epochs if mode == tf.estimator.ModeKeys.TRAIN else 1,
-                num_parallel_calls=args.num_parallel_calls,
+                num_parallel_calls=64 if args.tpu_name and args.tpu_name != 'fake' else args.num_parallel_calls,
                 max_frames=args.max_frames, max_symbols=args.max_symbols)
 
 

--- a/train.py
+++ b/train.py
@@ -2,6 +2,7 @@ import argparse
 import tensorflow as tf
 import multiprocessing
 import os
+from tensor2tensor.data_generators.text_encoder import PAD_ID, EOS_ID
 
 import utils
 
@@ -134,7 +135,8 @@ def main(args):
     else:
         config = tf.estimator.RunConfig(model_dir=args.model_dir)
     hparams = utils.create_hparams(
-        args, vocab_size, binf_count, utils.SOS_ID, utils.EOS_ID)
+        args, vocab_size, binf_count, utils.SOS_ID if not args.t2t_format else PAD_ID,
+        utils.EOS_ID if not args.t2t_format else EOS_ID)
     if mapping is not None:
         hparams.del_hparam('mapping')
         hparams.add_hparam('mapping', mapping)
@@ -160,7 +162,7 @@ def main(args):
         if args.t2t_format:
             return lambda params: utils.input_fn_t2t(args.train, mode, hparams,
                 batch_size=params.batch_size if 'batch_size' in params else args.batch_size,
-                num_epochs=args.num_epochs,
+                num_epochs=args.num_epochs if mode == tf.estimator.ModeKeys.TRAIN else 1,
                 num_parallel_calls=64 if args.tpu_name and args.tpu_name != 'fake' else args.num_parallel_calls,
                 max_frames=args.max_frames, max_symbols=args.max_symbols)
         else:

--- a/train.py
+++ b/train.py
@@ -1,5 +1,7 @@
 import argparse
 import tensorflow as tf
+import multiprocessing
+import os
 
 import utils
 
@@ -16,10 +18,12 @@ def parse_args():
                         help='training data in TFRecord format')
     parser.add_argument('--valid', type=str,
                         help='validation data in TFRecord format')
-    parser.add_argument('--vocab', type=str, required=True,
+    parser.add_argument('--vocab', type=str,
                         help='vocabulary table, listing vocabulary line by line')
     parser.add_argument('--norm', type=str, default=None,
                         help='normalization params')
+    parser.add_argument('--t2t_format', action='store_true',
+                        help='Use dataset in the format of ASR problems of Tensor2Tensor framework. --train param should be directory')
     parser.add_argument('--mapping', type=str,
                         help='additional mapping when evaluation')
     parser.add_argument('--model_dir', type=str, required=True,
@@ -57,7 +61,7 @@ def parse_args():
 
     parser.add_argument('--batch_size', type=int, default=8,
                         help='batch size')
-    parser.add_argument('--num_parallel_calls', type=int, default=32,
+    parser.add_argument('--num_parallel_calls', type=int, default=multiprocessing.cpu_count(),
                         help='Number of elements to be processed in parallel during the dataset transformation')
     parser.add_argument('--num_channels', type=int, default=39,
                         help='number of input channels')
@@ -87,6 +91,8 @@ def parse_args():
                         help='with --output_ipa, do not use ipa sampling algorithm for trainin, only for validation')
     parser.add_argument('--binf_projection', action='store_true',
                         help='with --binary_outputs and --output_ipa, use binary features mapping instead of decoder''s projection layer.')
+    parser.add_argument('--binf_trainable', action='store_true',
+                        help='trainable binary features matrix'),
     parser.add_argument('--multitask', action='store_true',
                         help='with --binary_outputs use both binary features and IPA decoders.')
     parser.add_argument('--tpu_name', type=str, default='', help='TPU name. Leave blank to prevent TPU training.')
@@ -97,35 +103,9 @@ def parse_args():
 
     return parser.parse_args()
 
-
-def input_fn(dataset_filename, vocab_filename, norm_filename=None, num_channels=39, batch_size=8, num_epochs=1,
-    binf2phone=None, num_parallel_calls=32, max_frames=-1, max_symbols=-1):
-    binary_targets = binf2phone is not None
-    labels_shape = [] if not binary_targets else len(binf2phone.index)
-    labels_dtype = tf.string if not binary_targets else tf.float32
-    dataset = utils.read_dataset(dataset_filename, num_channels, labels_shape=labels_shape,
-        labels_dtype=labels_dtype)
-    vocab_table = utils.create_vocab_table(vocab_filename)
-
-    if norm_filename is not None:
-        means, stds = utils.load_normalization(args.norm)
-    else:
-        means = stds = None
-
-    sos = binf2phone[utils.SOS].values if binary_targets else utils.SOS
-    eos = binf2phone[utils.EOS].values if binary_targets else utils.EOS
-
-    dataset = utils.process_dataset(
-        dataset, vocab_table, sos, eos, means, stds, batch_size, num_epochs,
-        binary_targets=binary_targets, labels_shape=labels_shape, num_parallel_calls=num_parallel_calls,
-        max_frames=max_frames, max_symbols=max_symbols
-    )
-
-    return dataset
-
-
 def main(args):
-    vocab_list = utils.load_vocab(args.vocab)
+    vocab_name = args.vocab if not args.t2t_format else os.path.join(args.train, 'vocab.txt')
+    vocab_list = utils.load_vocab(vocab_name)
     binf2phone_np = None
     mapping = None
     vocab_size = len(vocab_list)
@@ -176,21 +156,31 @@ def main(args):
             config=config,
             params=hparams)
 
-    if args.valid:
-        train_spec = tf.estimator.TrainSpec(
-            input_fn=lambda params: input_fn(
-                args.train, args.vocab, args.norm, num_channels=args.num_channels,
+    def create_input_fn(mode):
+        if args.t2t_format:
+            return lambda params: utils.input_fn_t2t(args.train, mode, hparams,
                 batch_size=params.batch_size if 'batch_size' in params else args.batch_size,
-                num_epochs=args.num_epochs, binf2phone=None, num_parallel_calls=args.num_parallel_calls,
-                max_frames=args.max_frames, max_symbols=args.max_symbols),
+                num_epochs=args.num_epochs,
+                num_parallel_calls=64 if args.tpu_name and args.tpu_name != 'fake' else args.num_parallel_calls,
+                max_frames=args.max_frames, max_symbols=args.max_symbols)
+        else:
+            return lambda params: utils.input_fn(
+                args.valid if mode == tf.estimator.ModeKeys.EVAL and args.valid else args.train,
+                args.vocab, args.norm, num_channels=args.num_channels,
+                batch_size=params.batch_size if 'batch_size' in params else args.batch_size,
+                num_epochs=args.num_epochs if mode == tf.estimator.ModeKeys.TRAIN else 1,
+                num_parallel_calls=args.num_parallel_calls,
+                max_frames=args.max_frames, max_symbols=args.max_symbols)
+
+
+    if args.valid or args.t2t_format:
+        train_spec = tf.estimator.TrainSpec(
+            input_fn=create_input_fn(tf.estimator.ModeKeys.TRAIN),
             max_steps=args.num_epochs * 1000 * args.batch_size
         )
 
         eval_spec = tf.estimator.EvalSpec(
-            input_fn=lambda params: input_fn(
-                args.valid or args.train, args.vocab, args.norm, num_channels=args.num_channels,
-                batch_size=params.batch_size if 'batch_size' in params else args.batch_size, binf2phone=None,
-                num_parallel_calls=args.num_parallel_calls, max_frames=args.max_frames, max_symbols=args.max_symbols),
+            input_fn=create_input_fn(tf.estimator.ModeKeys.EVAL),
             start_delay_secs=60,
             throttle_secs=args.eval_secs)
 
@@ -198,11 +188,7 @@ def main(args):
     else:
         tf.logging.warning('Training without evaluation!')
         model.train(
-            input_fn=lambda params: input_fn(
-                args.train, args.vocab, args.norm, num_channels=args.num_channels,
-                batch_size=params.batch_size if 'batch_size' in params else args.batch_size,
-                num_epochs=args.num_epochs, binf2phone=None, num_parallel_calls=args.num_parallel_calls,
-                max_frames=args.max_frames, max_symbols=args.max_symbols),
+            input_fn=create_input_fn(tf.estimator.ModeKeys.TRAIN),
             steps=args.num_epochs * 1000 * args.batch_size
         )
 

--- a/train.py
+++ b/train.py
@@ -25,6 +25,8 @@ def parse_args():
                         help='normalization params')
     parser.add_argument('--t2t_format', action='store_true',
                         help='Use dataset in the format of ASR problems of Tensor2Tensor framework. --train param should be directory')
+    parser.add_argument('--t2t_problem_name', type=str,
+                        help='Problem name for data in T2T format.')
     parser.add_argument('--mapping', type=str,
                         help='additional mapping when evaluation')
     parser.add_argument('--model_dir', type=str, required=True,
@@ -161,6 +163,7 @@ def main(args):
     def create_input_fn(mode):
         if args.t2t_format:
             return lambda params: utils.input_fn_t2t(args.train, mode, hparams,
+                args.t2t_problem_name,
                 batch_size=params.batch_size if 'batch_size' in params else args.batch_size,
                 num_epochs=args.num_epochs if mode == tf.estimator.ModeKeys.TRAIN else 1,
                 num_parallel_calls=64 if args.tpu_name and args.tpu_name != 'fake' else args.num_parallel_calls,

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -10,9 +10,9 @@ __all__ = [
     'input_fn_t2t'
 ]
 
-def read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_symbols):
+def read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_symbols, t2t_problem_name):
     problem = SpeechRecognitionProblem()
-    problem.name = 'asr_ipa_precalc'
+    problem.name = t2t_problem_name
     speech_params = transformer_librispeech_tpu()
     speech_params.max_input_seq_length = max_frames
     speech_params.max_target_seq_length = max_symbols
@@ -106,9 +106,10 @@ def process_dataset_t2t_format(dataset, sos_id, eos_id,
 
     return dataset
 
-def input_fn_t2t(data_dir, mode, hparams, batch_size=8, num_epochs=1,
+def input_fn_t2t(data_dir, mode, hparams, t2t_problem_name, batch_size=8, num_epochs=1,
     num_parallel_calls=32, max_frames=-1, max_symbols=-1, take=0):
-    dataset = read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_symbols)
+    dataset = read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames,
+        max_symbols, t2t_problem_name)
 
     dataset = process_dataset_t2t_format(
         dataset, hparams.decoder.sos_id, hparams.decoder.eos_id, batch_size, num_epochs,

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -50,8 +50,8 @@ def process_dataset_t2t_format(dataset, sos_id, eos_id,
 
     dataset = dataset.map(
         lambda inputs, labels: (inputs,
-                                tf.concat(([sos_id], labels), 0),
-                                tf.concat((labels, [eos_id]), 0)),
+                                tf.concat(([sos_id], labels[:-1]), 0),
+                                labels),
         num_parallel_calls=num_parallel_calls)
 
     dataset = dataset.map(

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -1,20 +1,134 @@
 import tensorflow as tf
+import tensorflow.contrib as tf_contrib
 import numpy as np
+from tensor2tensor.data_generators.speech_recognition import SpeechRecognitionProblem
+from tensor2tensor.models.transformer import transformer_librispeech_tpu
+import utils
 
 __all__ = [
-    'read_dataset',
-    'process_dataset',
+    'input_fn',
+    'input_fn_t2t'
 ]
 
+def read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_symbols):
+    problem = SpeechRecognitionProblem()
+    problem.name = 'asr_ipa_precalc'
+    speech_params = transformer_librispeech_tpu()
+    speech_params.max_input_seq_length = max_frames
+    speech_params.max_target_seq_length = max_symbols
+    dataset = problem.dataset(mode, data_dir=data_dir, num_threads=num_parallel_calls, hparams=speech_params)
+    return dataset
 
-def read_dataset(filename, num_channels=39, labels_shape=[], labels_dtype=tf.string):
+def process_dataset_t2t_format(dataset, sos_id, eos_id,
+    batch_size=8, num_epochs=1, num_parallel_calls=32, is_infer=False,
+    max_frames=-1, max_symbols=-1):
+    output_buffer_size = batch_size * 1000
+
+    channels_count = dataset.output_shapes['inputs'][1] * dataset.output_shapes['inputs'][2]
+
+    dataset = dataset.map(
+        lambda inputs: (
+            tf.reshape(inputs['inputs'], (tf.shape(inputs['inputs'])[0], channels_count)),
+            inputs['targets']),
+        num_parallel_calls=num_parallel_calls
+    )
+
+    if max_frames > 0:
+        dataset = dataset.filter(
+            lambda inputs, labels: tf.logical_and(tf.shape(inputs)[0] <= max_frames,
+                                                    tf.shape(labels)[0] <= max_symbols))
+
+    dataset = dataset.repeat(num_epochs if num_epochs > 0 else None)
+
+    if not is_infer:
+        dataset = dataset.shuffle(output_buffer_size)
+
+    dataset = dataset.map(
+        lambda inputs, labels: (tf.cast(inputs, tf.float32),
+                                tf.cast(labels, tf.int32)),
+        num_parallel_calls=num_parallel_calls)
+
+    dataset = dataset.map(
+        lambda inputs, labels: (inputs,
+                                tf.concat(([sos_id], labels), 0),
+                                tf.concat((labels, [eos_id]), 0)),
+        num_parallel_calls=num_parallel_calls)
+
+    dataset = dataset.map(
+        lambda inputs, labels_in, labels_out: (inputs,
+                                            labels_in,
+                                            labels_out,
+                                            tf.shape(inputs)[0],
+                                            tf.size(labels_in)),
+        num_parallel_calls=num_parallel_calls)
+
+    dataset = dataset.map(
+        lambda inputs, labels_in, labels_out,
+        source_sequence_length, target_sequence_length: (
+            {
+                'encoder_inputs': inputs,
+                'source_sequence_length': source_sequence_length,
+            },
+            {
+                'targets_inputs': labels_in,
+                'targets_outputs': labels_out,
+                'target_sequence_length': target_sequence_length
+            }))
+
+    if max_frames > 0:
+        padded_shapes = (
+            {
+                'encoder_inputs': tf.TensorShape([max_frames, dataset.output_shapes[0]['encoder_inputs'][1].value]),
+                'source_sequence_length': dataset.output_shapes[0]['source_sequence_length']
+            },
+            {
+                'targets_inputs': tf.TensorShape([max_symbols]),
+                'targets_outputs': tf.TensorShape([max_symbols]),
+                'target_sequence_length': dataset.output_shapes[1]['target_sequence_length'],
+            }
+        )
+    else:
+        padded_shapes = dataset.output_shapes
+    dataset = dataset.padded_batch(
+        batch_size,
+        padded_shapes=padded_shapes,
+        padding_values=(
+            {
+                'encoder_inputs': 0.0,
+                'source_sequence_length': 0,
+            },
+            {
+                'targets_inputs': eos_id,
+                'targets_outputs': eos_id,
+                'target_sequence_length': 0,
+            }),
+        drop_remainder=True)
+
+    return dataset
+
+def input_fn_t2t(data_dir, mode, hparams, batch_size=8, num_epochs=1,
+    num_parallel_calls=32, max_frames=-1, max_symbols=-1, take=0):
+    dataset = read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_symbols)
+
+    dataset = process_dataset_t2t_format(
+        dataset, hparams.decoder.sos_id, hparams.decoder.eos_id, batch_size, num_epochs,
+        num_parallel_calls=num_parallel_calls,
+        max_frames=max_frames, max_symbols=max_symbols
+    )
+
+    if take > 0:
+        dataset = dataset.take(take)
+
+    return dataset
+
+def read_dataset(filename, num_channels=39):
     """Read data from tfrecord file."""
 
     def parse_fn(example_proto):
         """Parse function for reading single sequence example."""
         sequence_features = {
             'inputs': tf.FixedLenSequenceFeature(shape=[num_channels], dtype=tf.float32),
-            'labels': tf.FixedLenSequenceFeature(labels_shape, labels_dtype)
+            'labels': tf.FixedLenSequenceFeature([], tf.string)
         }
 
         context, sequence = tf.parse_single_sequence_example(
@@ -35,7 +149,7 @@ def read_dataset(filename, num_channels=39, labels_shape=[], labels_dtype=tf.str
 
 def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
     batch_size=8, num_epochs=1, num_parallel_calls=32, is_infer=False,
-    binary_targets=False, labels_shape=[], max_frames=-1, max_symbols=-1):
+    max_frames=-1, max_symbols=-1):
 
     try:
         use_labels = len(dataset.output_classes) == 2
@@ -70,20 +184,18 @@ def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
                 lambda inputs, labels: tf.logical_and(tf.shape(inputs)[0] <= max_frames,
                                                       tf.shape(labels)[0] <= max_symbols))
 
-        if not binary_targets:
-            sos_id = tf.cast(vocab_table.lookup(tf.constant(sos)), tf.int32)
-            eos_id = tf.cast(vocab_table.lookup(tf.constant(eos)), tf.int32)
+        sos_id = tf.cast(vocab_table.lookup(tf.constant(sos)), tf.int32)
+        eos_id = tf.cast(vocab_table.lookup(tf.constant(eos)), tf.int32)
 
         dataset = dataset.repeat(num_epochs if num_epochs > 0 else None)
 
         if not is_infer:
             dataset = dataset.shuffle(output_buffer_size)
 
-        if not binary_targets:
-            dataset = dataset.map(
-                lambda inputs, labels: (inputs,
-                                        vocab_table.lookup(labels)),
-                num_parallel_calls=num_parallel_calls)
+        dataset = dataset.map(
+            lambda inputs, labels: (inputs,
+                                    vocab_table.lookup(labels)),
+            num_parallel_calls=num_parallel_calls)
 
         if means is not None and stds is not None:
             tf.logging.info('Applying normalization.')
@@ -99,29 +211,18 @@ def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
                                     tf.cast(labels, tf.int32)),
             num_parallel_calls=num_parallel_calls)
 
-        if binary_targets:
-            sos_id = sos[np.newaxis, :]
-            eos_id = eos[np.newaxis, :]
-
-            dataset = dataset.map(
-                lambda inputs, labels: (inputs,
-                                        tf.concat((sos_id, labels), 0),
-                                        tf.concat((labels, eos_id), 0),
-                                    ),
-                num_parallel_calls=num_parallel_calls)
-        else:
-            dataset = dataset.map(
-                lambda inputs, labels: (inputs,
-                                        tf.concat(([sos_id], labels), 0),
-                                        tf.concat((labels, [eos_id]), 0)),
-                num_parallel_calls=num_parallel_calls)
+        dataset = dataset.map(
+            lambda inputs, labels: (inputs,
+                                    tf.concat(([sos_id], labels), 0),
+                                    tf.concat((labels, [eos_id]), 0)),
+            num_parallel_calls=num_parallel_calls)
 
         dataset = dataset.map(
             lambda inputs, labels_in, labels_out: (inputs,
                                                 labels_in,
                                                 labels_out,
                                                 tf.shape(inputs)[0],
-                                                tf.shape(labels_in)[0] if binary_targets else tf.size(labels_in)),
+                                                tf.size(labels_in)),
             num_parallel_calls=num_parallel_calls)
 
         dataset = dataset.map(
@@ -160,10 +261,34 @@ def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
                     'source_sequence_length': 0,
                 },
                 {
-                    'targets_inputs': 0 if binary_targets else eos_id,
-                    'targets_outputs': 0 if binary_targets else eos_id,
+                    'targets_inputs': eos_id,
+                    'targets_outputs': eos_id,
                     'target_sequence_length': 0,
                 }),
             drop_remainder=True)
+
+    return dataset
+
+def input_fn(dataset_filename, vocab_filename, norm_filename=None, num_channels=39, batch_size=8, num_epochs=1,
+    num_parallel_calls=32, max_frames=-1, max_symbols=-1, take=0, is_infer=False):
+    dataset = read_dataset(dataset_filename, num_channels)
+    vocab_table = utils.create_vocab_table(vocab_filename)
+
+    if norm_filename is not None:
+        means, stds = utils.load_normalization(norm_filename)
+    else:
+        means = stds = None
+
+    sos = utils.SOS
+    eos = utils.EOS
+
+    dataset = process_dataset(
+        dataset, vocab_table, sos, eos, means, stds, batch_size, num_epochs,
+        num_parallel_calls=num_parallel_calls,
+        max_frames=max_frames, max_symbols=max_symbols
+    )
+
+    if take > 0:
+        dataset = dataset.take(take)
 
     return dataset

--- a/utils/params_utils.py
+++ b/utils/params_utils.py
@@ -62,6 +62,7 @@ def get_default_hparams():
         binary_outputs=False,
         binf_sampling=False,
         binf_projection=False,
+        binf_trainable=False,
         multitask=False,
         # evaluation setting
         mapping=None)
@@ -125,6 +126,7 @@ def get_encoder_decoder_hparams(hparams):
     binary_outputs = hparams.pop_hparam('binary_outputs')
     binf_sampling = hparams.pop_hparam('binf_sampling')
     binf_projection = hparams.pop_hparam('binf_projection')
+    binf_trainable = hparams.pop_hparam('binf_trainable')
     multitask = hparams.pop_hparam('multitask')
 
     encoder_hparams = HParams(
@@ -142,7 +144,8 @@ def get_encoder_decoder_hparams(hparams):
         binf_sampling=binf_sampling,
         binf_projection=binf_projection,
         max_symbols=max_symbols,
-        multitask=multitask)
+        multitask=multitask,
+        binf_trainable=binf_trainable)
 
     for name, value in hparams.values().items():
         decoder_hparams.add_hparam(name, value)

--- a/utils/params_utils.py
+++ b/utils/params_utils.py
@@ -1,5 +1,6 @@
 import os
 import json
+import tensorflow as tf
 import tensorflow.contrib as tf_contrib
 
 __all__ = [
@@ -21,7 +22,7 @@ class HParams(tf_contrib.training.HParams):
         return value
 
     def save_to_file(self, filename):
-        with open(filename, 'w') as f:
+        with tf.gfile.Open(filename, 'w') as f:
             json.dump(self.to_json(), f)
 
 
@@ -78,8 +79,8 @@ def create_hparams(args, target_vocab_size=None, binf_count=None, sos_id=1, eos_
         is_reset = args.reset
     except AttributeError:
         is_reset = False
-    if os.path.exists(hparams_file) and not is_reset:
-        with open(hparams_file, 'r') as f:
+    if tf.gfile.Exists(hparams_file) and not is_reset:
+        with tf.gfile.Open(hparams_file, 'r') as f:
             hparams_dict = json.loads(json.load(f))
 
         for name, value in vars(args).items():
@@ -99,14 +100,14 @@ def create_hparams(args, target_vocab_size=None, binf_count=None, sos_id=1, eos_
         if value is not None:
             if name == 'mapping':
                 if not isinstance(value, list):
-                    value = [int(x.strip()) for x in open(value, 'r')]
+                    value = [int(x.strip()) for x in tf.gfile.Open(value, 'r')]
                 hparams.del_hparam(name)
                 hparams.add_hparam(name, value)
             else:
                 hparams.set_hparam(name, value)
 
-    if not os.path.exists(args.model_dir):
-        os.makedirs(args.model_dir)
+    if not tf.gfile.Exists(args.model_dir):
+        tf.gfile.MkDir(args.model_dir)
     hparams.save_to_file(hparams_file)
 
     return get_encoder_decoder_hparams(hparams)

--- a/utils/params_utils.py
+++ b/utils/params_utils.py
@@ -22,7 +22,7 @@ class HParams(tf_contrib.training.HParams):
         return value
 
     def save_to_file(self, filename):
-        with tf.gfile.Open(filename, 'w') as f:
+        with tf.io.gfile.GFile(filename, 'w') as f:
             json.dump(self.to_json(), f)
 
 
@@ -79,8 +79,8 @@ def create_hparams(args, target_vocab_size=None, binf_count=None, sos_id=1, eos_
         is_reset = args.reset
     except AttributeError:
         is_reset = False
-    if tf.gfile.Exists(hparams_file) and not is_reset:
-        with tf.gfile.Open(hparams_file, 'r') as f:
+    if tf.io.gfile.exists(hparams_file) and not is_reset:
+        with tf.io.gfile.GFile(hparams_file, 'r') as f:
             hparams_dict = json.loads(json.load(f))
 
         for name, value in vars(args).items():
@@ -100,14 +100,14 @@ def create_hparams(args, target_vocab_size=None, binf_count=None, sos_id=1, eos_
         if value is not None:
             if name == 'mapping':
                 if not isinstance(value, list):
-                    value = [int(x.strip()) for x in tf.gfile.Open(value, 'r')]
+                    value = [int(x.strip()) for x in tf.io.gfile.GFile(value, 'r')]
                 hparams.del_hparam(name)
                 hparams.add_hparam(name, value)
             else:
                 hparams.set_hparam(name, value)
 
-    if not tf.gfile.Exists(args.model_dir):
-        tf.gfile.MkDir(args.model_dir)
+    if not tf.io.gfile.exists(args.model_dir):
+        tf.io.gfile.mkdir(args.model_dir)
     hparams.save_to_file(hparams_file)
 
     return get_encoder_decoder_hparams(hparams)

--- a/utils/vocab_utils.py
+++ b/utils/vocab_utils.py
@@ -23,11 +23,11 @@ EOS_ID = 2
 
 def load_vocab(filename):
     if not '.pickle' in filename:
-        with tf.gfile.Open(filename, 'r') as f:
+        with tf.io.gfile.GFile(filename, 'r') as f:
             vocab_list = [vocab.strip('\r\n') for vocab in f]
             vocab_list = [UNK, SOS, EOS] + vocab_list
     else:
-        with tf.gfile.Open(filename, 'rb') as f:
+        with tf.io.gfile.GFile(filename, 'rb') as f:
             vocab_list = pickle.load(f)
             vocab_list = [UNK, SOS, EOS] + vocab_list
 


### PR DESCRIPTION
* Removing binary features from `input_fn`, as soon as all our datasets contain phonemes, binary features are obtained via mapping matrix.
* Adding `--t2t_format` flag to use with datasets collected for Tensor2Tensor framework, e.g. [CommonVoice](https://github.com/sciforce/t2t_problems) problem.
* Fixing `build_vocab` for Tensor2Tensor format to enable getting  maximal lengths.
* Fixing parameters save/load at TPU training.
* Enabling trainable binary features via `--binf_trainable` (may have conflicts with other branches).