### PR TITLE
Tpu checkpoints interval

### DIFF
--- a/build_vocab.py
+++ b/build_vocab.py
@@ -1,6 +1,8 @@
 import argparse
 import tensorflow as tf
 from tqdm import tqdm
+import matplotlib
+import matplotlib.pyplot as plt
 
 from utils.dataset_utils import read_dataset, read_dataset_t2t_format
 
@@ -8,17 +10,22 @@ from utils.dataset_utils import read_dataset, read_dataset_t2t_format
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, required=True)
-    parser.add_argument('--num_channels', type=int, required=True)
+    parser.add_argument('--num_channels', type=int)
     parser.add_argument('--output', type=str, default=None)
     parser.add_argument('--t2t_format', action='store_true')
+    parser.add_argument('--t2t_problem_name', type=str,
+                        help='Problem name for data in T2T format.')
     args = parser.parse_args()
     vocab = set()
     if args.t2t_format:
-        dataset = read_dataset_t2t_format(args.data, 1, tf.estimator.ModeKeys.TRAIN, -1, -1)
+        dataset = read_dataset_t2t_format(args.data, 1, tf.estimator.ModeKeys.TRAIN,
+            -1, -1, args.t2t_problem_name)
     else:
         dataset = read_dataset(args.data, args.num_channels)
     read_op = dataset.make_one_shot_iterator().get_next()
     max_frames = max_symbols = 0
+    frames_count = []
+    symbols_count = []
     with tf.Session() as sess:
         handle = tqdm(None, unit='phrase')
         while True:
@@ -27,9 +34,12 @@ if __name__ == "__main__":
                     item = sess.run(read_op)
                     features, labels = item['inputs'], item['targets']
                     max_symbols = max([max_symbols, labels.shape[0]])
+                    symbols_count.append(labels.shape[0])
                 else:
                     features, label = sess.run(read_op)
                     max_symbols = max([max_symbols, len(label)])
+                    symbols_count.append(len(label))
+                frames_count.append(features.shape[0])
                 max_frames = max([max_frames, features.shape[0]])
                 if not args.t2t_format:
                     for x in label:
@@ -45,3 +55,9 @@ if __name__ == "__main__":
         else:
             with open(args.output, 'w') as f:
                 f.write('\n'.join(x for x in vocab))
+    matplotlib.use('TkAgg')
+    plt.subplot(211)
+    plt.hist(frames_count, bins=80)
+    plt.subplot(212)
+    plt.hist(symbols_count, bins=80)
+    plt.show()

--- a/eval.py
+++ b/eval.py
@@ -32,7 +32,7 @@ def parse_args():
                         help='number of input channels')
     parser.add_argument('--binf_map', type=str, default='misc/binf_map.csv',
                         help='Path to CSV with phonemes to binary features map')
-    parser.add_argument('--features_hparams_override', type=str, default='',
+    parser.add_argument('--t2t_features_hparams_override', type=str, default='',
                         help='String with overrided parameters used by Tensor2Tensor problem.')
 
     return parser.parse_args()
@@ -65,7 +65,7 @@ def main(args):
         input_fn = lambda: utils.input_fn_t2t(
             args.data, tf.estimator.ModeKeys.EVAL, hparams,
             args.t2t_problem_name, batch_size=args.batch_size,
-            features_hparams_override=args.features_hparams_override)
+            features_hparams_override=args.t2t_features_hparams_override)
     else:
         input_fn = lambda: utils.input_fn(
             args.data, args.vocab, args.norm, num_channels=args.num_channels,

--- a/eval.py
+++ b/eval.py
@@ -32,6 +32,8 @@ def parse_args():
                         help='number of input channels')
     parser.add_argument('--binf_map', type=str, default='misc/binf_map.csv',
                         help='Path to CSV with phonemes to binary features map')
+    parser.add_argument('--features_hparams_override', type=str, default='',
+                        help='String with overrided parameters used by Tensor2Tensor problem.')
 
     return parser.parse_args()
 
@@ -62,7 +64,8 @@ def main(args):
     if args.t2t_format:
         input_fn = lambda: utils.input_fn_t2t(
             args.data, tf.estimator.ModeKeys.EVAL, hparams,
-            args.t2t_problem_name, batch_size=args.batch_size)
+            args.t2t_problem_name, batch_size=args.batch_size,
+            features_hparams_override=args.features_hparams_override)
     else:
         input_fn = lambda: utils.input_fn(
             args.data, args.vocab, args.norm, num_channels=args.num_channels,

--- a/model_helper.py
+++ b/model_helper.py
@@ -230,8 +230,11 @@ def las_model_fn(features,
                     sample_ids_phones_binf = tf.to_int32(tf.argmax(logits_binf, -1))
 
     if mode == tf.estimator.ModeKeys.PREDICT:
-        emb_c = tf.concat([x.c for x in encoder_state], axis=1)
-        emb_h = tf.concat([x.h for x in encoder_state], axis=1)
+        try:
+            emb_c = tf.concat([x.c for x in encoder_state], axis=1)
+            emb_h = tf.concat([x.h for x in encoder_state], axis=1)
+        except AttributeError:
+            emb_c, emb_h = encoder_state.c, encoder_state.h
         emb = tf.stack([emb_c, emb_h], axis=1)
         predictions = {
             'embedding': emb,

--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ def parse_args():
                         help='If positives, sets that much frames for each batch.')
     parser.add_argument('--max_symbols', type=int, default=-1,
                         help='If positives, sets that much symbols for each batch.')
+    parser.add_argument('--tpu_checkpoints_interval', type=int, default=600,
+                        help='Interval for saving checkpoints on TPU, in steps.')
 
     return parser.parse_args()
 
@@ -130,7 +132,7 @@ def main(args):
         config = tf.estimator.tpu.RunConfig(
             cluster=tpu_cluster_resolver,
             model_dir=args.model_dir,
-            save_checkpoints_steps=max(600, iterations_per_loop),
+            save_checkpoints_steps=max(args.tpu_checkpoints_interval, iterations_per_loop),
             tpu_config=tf.estimator.tpu.TPUConfig(
                 iterations_per_loop=iterations_per_loop,
                 per_host_input_for_training=tf.estimator.tpu.InputPipelineConfig.PER_HOST_V2))

--- a/train.py
+++ b/train.py
@@ -105,7 +105,7 @@ def parse_args():
                         help='If positives, sets that much symbols for each batch.')
     parser.add_argument('--tpu_checkpoints_interval', type=int, default=600,
                         help='Interval for saving checkpoints on TPU, in steps.')
-    parser.add_argument('--features_hparams_override', type=str, default='',
+    parser.add_argument('--t2t_features_hparams_override', type=str, default='',
                         help='String with overrided parameters used by Tensor2Tensor problem.')
 
     return parser.parse_args()
@@ -172,7 +172,7 @@ def main(args):
                 num_epochs=args.num_epochs if mode == tf.estimator.ModeKeys.TRAIN else 1,
                 num_parallel_calls=64 if args.tpu_name and args.tpu_name != 'fake' else args.num_parallel_calls,
                 max_frames=args.max_frames, max_symbols=args.max_symbols,
-                features_hparams_override=args.features_hparams_override)
+                features_hparams_override=args.t2t_features_hparams_override)
         else:
             return lambda params: utils.input_fn(
                 args.valid if mode == tf.estimator.ModeKeys.EVAL and args.valid else args.train,

--- a/train.py
+++ b/train.py
@@ -105,6 +105,8 @@ def parse_args():
                         help='If positives, sets that much symbols for each batch.')
     parser.add_argument('--tpu_checkpoints_interval', type=int, default=600,
                         help='Interval for saving checkpoints on TPU, in steps.')
+    parser.add_argument('--features_hparams_override', type=str, default='',
+                        help='String with overrided parameters used by Tensor2Tensor problem.')
 
     return parser.parse_args()
 
@@ -169,7 +171,8 @@ def main(args):
                 batch_size=params.batch_size if 'batch_size' in params else args.batch_size,
                 num_epochs=args.num_epochs if mode == tf.estimator.ModeKeys.TRAIN else 1,
                 num_parallel_calls=64 if args.tpu_name and args.tpu_name != 'fake' else args.num_parallel_calls,
-                max_frames=args.max_frames, max_symbols=args.max_symbols)
+                max_frames=args.max_frames, max_symbols=args.max_symbols,
+                features_hparams_override=args.features_hparams_override)
         else:
             return lambda params: utils.input_fn(
                 args.valid if mode == tf.estimator.ModeKeys.EVAL and args.valid else args.train,

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -10,8 +10,14 @@ __all__ = [
     'input_fn_t2t'
 ]
 
-def read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_symbols, t2t_problem_name):
-    problem = SpeechRecognitionProblem()
+def read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_symbols, t2t_problem_name,
+    features_hparams_override=''):
+    class CustomProblem(SpeechRecognitionProblem):
+        def hparams(self, defaults, model_hparams):
+            super().hparams(defaults, model_hparams)
+            model_hparams.parse(features_hparams_override)
+
+    problem = CustomProblem()
     problem.name = t2t_problem_name
     speech_params = transformer_librispeech_tpu()
     speech_params.max_input_seq_length = max_frames
@@ -107,9 +113,9 @@ def process_dataset_t2t_format(dataset, sos_id, eos_id,
     return dataset
 
 def input_fn_t2t(data_dir, mode, hparams, t2t_problem_name, batch_size=8, num_epochs=1,
-    num_parallel_calls=32, max_frames=-1, max_symbols=-1, take=0):
+    num_parallel_calls=32, max_frames=-1, max_symbols=-1, take=0, features_hparams_override=''):
     dataset = read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames,
-        max_symbols, t2t_problem_name)
+        max_symbols, t2t_problem_name, features_hparams_override)
 
     dataset = process_dataset_t2t_format(
         dataset, hparams.decoder.sos_id, hparams.decoder.eos_id, batch_size, num_epochs,


### PR DESCRIPTION
* Adding `--hparams_override` argument for overriding features calculation parameters with T2T problems. Parameters are defined at [here](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/data_generators/speech_recognition.py). For example, setting `num_zeropad_frames` can sufficiently reduce computation time and memory usage.
* Adding `--tpu_checkpoints_interval` for TPU training to reduce cloud storage I/O.
* Adding histograms to `build_vocab` script.