### PR TITLE
Binary features projection fix

### DIFF
--- a/model_helper.py
+++ b/model_helper.py
@@ -137,9 +137,9 @@ def compute_log_probs_loss(outputs):
     nfeatures = outputs.shape[-1] // 2
     log_prob_ones = outputs[..., :nfeatures]
     log_prob_zeros = outputs[..., nfeatures:2 * nfeatures]
-    # Normalization constant to ensure numerical stability
+    # Normalization constant to ensure numerical stability. No gradients are needed, as soon as it's a constant.
     norm_const = tf.stop_gradient(-(log_prob_ones + log_prob_zeros) / 2)
-    # Enforce `p0 + p1 = 1`
+    # Enforce `p0 + p1 = 1. Multiply and divide by `e^norm_const` to ensure numerical stability.
     loss = tf.abs((tf.exp(log_prob_ones + norm_const) + tf.exp(log_prob_zeros + norm_const)) / tf.exp(norm_const) - 1)
     # Enforce `0 <= p0 <= 1` and `0 <= p1 <= 1`
     loss += tf.nn.relu(log_prob_ones) + tf.nn.relu(log_prob_zeros)

--- a/model_helper.py
+++ b/model_helper.py
@@ -134,7 +134,7 @@ def compute_log_probs_loss(outputs):
     log_prob_ones = outputs[..., :nfeatures]
     log_prob_zeros = outputs[..., nfeatures:]
     norm_const = tf.stop_gradient(-(log_prob_ones + log_prob_zeros) / 2)
-    loss = (tf.exp(log_prob_ones + norm_const) + tf.exp(log_prob_zeros + norm_const)) / tf.exp(norm_const) - 1
+    loss = tf.abs((tf.exp(log_prob_ones + norm_const) + tf.exp(log_prob_zeros + norm_const)) / tf.exp(norm_const) - 1)
     loss += tf.nn.relu(log_prob_ones) + tf.nn.relu(log_prob_zeros)
     return tf.reduce_mean(loss)
 
@@ -311,7 +311,7 @@ def las_model_fn(features,
                 audio_loss_binf = compute_loss(
                     logits_binf, targets, final_sequence_length_binf, target_sequence_length, mode, params.decoder.eos_id)
                 if raw_rnn_outputs is not None:
-                    audio_loss_binf += 1e-1 * compute_log_probs_loss(raw_rnn_outputs)
+                    audio_loss_binf += compute_log_probs_loss(raw_rnn_outputs)
             else:
                 if mode == tf.estimator.ModeKeys.TRAIN:
                     audio_loss_binf = compute_loss_sigmoid(logits_binf, targets_binf,

--- a/model_helper.py
+++ b/model_helper.py
@@ -129,6 +129,14 @@ def compute_loss_sigmoid(logits, targets, final_sequence_length, target_sequence
 
     return loss
 
+def compute_log_probs_loss(outputs):
+    nfeatures = outputs.shape[-1] // 2
+    log_prob_ones = outputs[..., :nfeatures]
+    log_prob_zeros = outputs[..., nfeatures:]
+    norm_const = tf.stop_gradient(-(log_prob_ones + log_prob_zeros) / 2)
+    loss = (tf.exp(log_prob_ones + norm_const) + tf.exp(log_prob_zeros + norm_const)) / tf.exp(norm_const) - 1
+    loss += tf.nn.relu(log_prob_ones) + tf.nn.relu(log_prob_zeros)
+    return tf.reduce_mean(loss)
 
 def get_alignment_history(final_context_state, params):
     try:
@@ -200,7 +208,7 @@ def las_model_fn(features,
                 source_sequence_length, target_sequence_length,
                 mode, params.decoder)
 
-    decoder_outputs_binf, final_context_state_binf, final_sequence_length_binf = None, None, None
+    decoder_outputs_binf, final_context_state_binf, final_sequence_length_binf, raw_rnn_outputs = None, None, None, None
     if params.decoder.binary_outputs:
         with tf.variable_scope('speller_binf'):
             decoder_outputs_binf, final_context_state_binf, final_sequence_length_binf = las.model.speller(
@@ -223,6 +231,10 @@ def las_model_fn(features,
                 sample_ids_phones = tf.to_int32(tf.argmax(logits, -1))
             if decoder_outputs_binf is not None:
                 logits_binf = decoder_outputs_binf.rnn_output
+                if params.decoder.binf_projection and mode == tf.estimator.ModeKeys.TRAIN:
+                    raw_rnn_outputs = logits_binf[..., binf2phone.shape[-1]:]
+                    logits_binf = logits_binf[..., :binf2phone.shape[-1]]
+
                 if params.decoder.binary_outputs and params.decoder.binf_sampling:
                     logits_phones_binf = transform_binf_to_phones(logits_binf, binf_embedding)
                     sample_ids_phones_binf = tf.to_int32(tf.argmax(logits_phones_binf, -1))
@@ -230,17 +242,21 @@ def las_model_fn(features,
                     sample_ids_phones_binf = tf.to_int32(tf.argmax(logits_binf, -1))
 
     if mode == tf.estimator.ModeKeys.PREDICT:
+        predictions = {
+            'encoder_out': encoder_outputs,
+            'source_length': source_sequence_length
+        }
         try:
             emb_c = tf.concat([x.c for x in encoder_state], axis=1)
             emb_h = tf.concat([x.h for x in encoder_state], axis=1)
         except AttributeError:
-            emb_c, emb_h = encoder_state.c, encoder_state.h
-        emb = tf.stack([emb_c, emb_h], axis=1)
-        predictions = {
-            'embedding': emb,
-            'encoder_out': encoder_outputs,
-            'source_length': source_sequence_length
-        }
+            try:
+                emb_c, emb_h = encoder_state.c, encoder_state.h
+            except:
+                emb_c, emb_h = None, None
+        if emb_c and emb_h:
+            emb = tf.stack([emb_c, emb_h], axis=1)
+            predictions['embedding'] = emb
         if sample_ids_phones is not None:
             predictions['sample_ids'] = sample_ids_phones
         if logits_binf is not None:
@@ -294,6 +310,8 @@ def las_model_fn(features,
             if params.decoder.binf_projection:
                 audio_loss_binf = compute_loss(
                     logits_binf, targets, final_sequence_length_binf, target_sequence_length, mode, params.decoder.eos_id)
+                if raw_rnn_outputs is not None:
+                    audio_loss_binf += 1e-1 * compute_log_probs_loss(raw_rnn_outputs)
             else:
                 if mode == tf.estimator.ModeKeys.TRAIN:
                     audio_loss_binf = compute_loss_sigmoid(logits_binf, targets_binf,

--- a/train.py
+++ b/train.py
@@ -94,6 +94,8 @@ def parse_args():
                         help='with --output_ipa, do not use ipa sampling algorithm for trainin, only for validation')
     parser.add_argument('--binf_projection', action='store_true',
                         help='with --binary_outputs and --output_ipa, use binary features mapping instead of decoder''s projection layer.')
+    parser.add_argument('--binf_projection_reg_weight', type=float, default=1.0,
+                        help='with --binf_projection, weight for regularization term for binary features log probabilities.')
     parser.add_argument('--binf_trainable', action='store_true',
                         help='trainable binary features matrix'),
     parser.add_argument('--multitask', action='store_true',

--- a/utils/params_utils.py
+++ b/utils/params_utils.py
@@ -63,6 +63,7 @@ def get_default_hparams():
         binary_outputs=False,
         binf_sampling=False,
         binf_projection=False,
+        binf_projection_reg_weight=1.0,
         binf_trainable=False,
         multitask=False,
         # evaluation setting
@@ -127,6 +128,7 @@ def get_encoder_decoder_hparams(hparams):
     binary_outputs = hparams.pop_hparam('binary_outputs')
     binf_sampling = hparams.pop_hparam('binf_sampling')
     binf_projection = hparams.pop_hparam('binf_projection')
+    binf_projection_reg_weight = hparams.pop_hparam('binf_projection_reg_weight')
     binf_trainable = hparams.pop_hparam('binf_trainable')
     multitask = hparams.pop_hparam('multitask')
 
@@ -144,6 +146,7 @@ def get_encoder_decoder_hparams(hparams):
         binary_outputs=binary_outputs,
         binf_sampling=binf_sampling,
         binf_projection=binf_projection,
+        binf_projection_reg_weight=binf_projection_reg_weight,
         max_symbols=max_symbols,
         multitask=multitask,
         binf_trainable=binf_trainable)

--- a/utils/training_helper.py
+++ b/utils/training_helper.py
@@ -15,8 +15,9 @@ __all__ = [
 
 def transform_binf_to_phones(outputs, binf_to_ipa):
     # Transform binary features logits to phone log probabilities (unnormalized)
-    log_prob_ones = outputs[..., :binf_to_ipa.shape[0]]
-    log_prob_zeros = outputs[..., binf_to_ipa.shape[0]:]
+    nfeatures = binf_to_ipa.shape[0]
+    log_prob_ones = outputs[..., :nfeatures]
+    log_prob_zeros = outputs[..., nfeatures:2 * nfeatures]
     if outputs.shape.ndims == 3:
         binf_to_ipa_tiled = tf.tile(binf_to_ipa[None, :, :], [tf.shape(outputs)[0], 1, 1])
     else:

--- a/utils/training_helper.py
+++ b/utils/training_helper.py
@@ -15,12 +15,8 @@ __all__ = [
 
 def transform_binf_to_phones(outputs, binf_to_ipa):
     # Transform binary features logits to phone log probabilities (unnormalized)
-    # assert(outputs.shape[-1] // 2 == binf_to_ipa.shape[0])
     log_prob_ones = outputs[..., :binf_to_ipa.shape[0]]
     log_prob_zeros = outputs[..., binf_to_ipa.shape[0]:]
-    # log_prob_ones = -tf.log(1 + tf.exp(-outputs))
-    # log_prob_ones = tf.where(tf.is_inf(log_prob_ones), tf.zeros_like(log_prob_ones) - 1e6, log_prob_ones)
-    # log_prob_zeros = -outputs - log_prob_ones
     if outputs.shape.ndims == 3:
         binf_to_ipa_tiled = tf.tile(binf_to_ipa[None, :, :], [tf.shape(outputs)[0], 1, 1])
     else:


### PR DESCRIPTION
For the case of using binary features mapping matrix as projection layer, fixed potential gradients vanishing due to numerical errors caused by `exp` with huge values or `log` with small values.
Instead of converting unnormalized logits of binary features to log probabilities of outputs being zero or one via expressions which utilize `log` and `exp`, decoder is enforced to output explicit normalized log probabilities of ones and zeros (in other words, we got rid of sigmoid between decoder's outputs and projection layer). Additional regularizing term is added to loss to enforce decoder's outputs fit constraints for probability.