### PR TITLE
support for binary features output along with phones for commonly used model setup

### DIFF
--- a/las/model.py
+++ b/las/model.py
@@ -5,7 +5,8 @@ from tensorflow.python.util import nest
 
 from las.ops import lstm_cell
 from las.ops import pyramidal_bilstm
-from utils import TrainingSigmoidHelper, ScheduledSigmoidHelper, DenseBinfDecoder, TPUScheduledEmbeddingTrainingHelper
+from utils import TrainingSigmoidHelper, ScheduledSigmoidHelper, DenseBinfDecoder,\
+    TPUScheduledEmbeddingTrainingHelper, decoders_factory
 
 __all__ = [
     'listener',
@@ -209,7 +210,8 @@ def speller(encoder_outputs,
             mode,
             hparams,
             binary_outputs=False,
-            binf_embedding=None):
+            binf_embedding=None,
+            transparent_projection=False):
 
     batch_size = tf.shape(encoder_outputs)[0]
     beam_width = hparams.beam_width
@@ -338,7 +340,7 @@ def speller(encoder_outputs,
         helper = tf_contrib.seq2seq.GreedyEmbeddingHelper(
             embedding_fn, start_tokens, hparams.eos_id)
 
-        decoder = tf_contrib.seq2seq.BasicDecoder(
+        decoder = decoders_factory('basic_transparent' if transparent_projection else 'basic')(
             decoder_cell, helper, initial_state, output_layer=projection_layer)
 
     decoder_outputs, final_context_state, final_sequence_length = tf_contrib.seq2seq.dynamic_decode(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py
 absl-py==0.7.0
 astor==0.6.2
-bleach==3.1.2
+bleach==3.1.4
 gast==0.2.2
 grpcio==1.12.1
 html5lib==0.9999999

--- a/transcribe_audio_file.py
+++ b/transcribe_audio_file.py
@@ -1,9 +1,7 @@
 import argparse
-import os
 import tensorflow as tf
-import numpy as np
-from tqdm import tqdm
 import librosa
+from joblib import dump
 
 import utils
 from model_helper import las_model_fn
@@ -11,12 +9,9 @@ from preprocess_all import calculate_acoustic_features
 
 SAMPLE_RATE = 16000
 
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description='Listen, Attend and Spell(LAS) implementation based on Tensorflow. '
-                    'The model utilizes input pipeline and estimator API of Tensorflow, '
-                    'which makes the training procedure truly end-to-end.')
 
+def parse_args():
+    parser = argparse.ArgumentParser()
     parser.add_argument('--waveform', type=str, required=True,
                         help='Acoustic file')
     parser.add_argument('--vocab', type=str, required=True,
@@ -30,8 +25,6 @@ def parse_args():
 
     parser.add_argument('--beam_width', type=int, default=0,
                         help='number of beams (default 0: using greedy decoding)')
-    parser.add_argument('--batch_size', type=int, default=8,
-                        help='batch size')
 
     parser.add_argument('--delimiter', help='Symbols delimiter. Default: " "', type=str, default=' ')
     parser.add_argument('--binf_map', type=str, default='misc/binf_map.csv',
@@ -48,50 +41,41 @@ def parse_args():
     parser.add_argument('--step', help='Analysis window step in ms.', type=int, default=10)
     parser.add_argument('--deltas', help='Calculate deltas and double-deltas.', action='store_true')
     parser.add_argument('--energy', help='Compute energy.', action='store_true')
+    parser.add_argument('--output_file', help='location for saving predictions')
 
     return parser.parse_args()
 
-def input_fn(features, vocab_filename, norm_filename=None, num_channels=39, batch_size=8,
-             ground_truth=None):
+
+def input_fn(features, vocab_filename, norm_filename=None):
     def gen():
-        if ground_truth is not None:
-            iterable = zip(features, ground_truth)
-        else:
-            iterable = features
-        for item in iterable:
+        for item in features:
             yield item
 
-    output_types = (tf.float32, tf.string) if ground_truth is not None else tf.float32
     output_shapes = tf.TensorShape([None, features[0].shape[-1]])
-    if ground_truth is not None:
-        output_shapes = (output_shapes, tf.TensorShape([None, ground_truth[0].shape[-1]]))
-    dataset = tf.data.Dataset.from_generator(gen, output_types, output_shapes)
+    dataset = tf.data.Dataset.from_generator(gen, tf.float32, output_shapes)
     vocab_table = utils.create_vocab_table(vocab_filename)
-
     if norm_filename is not None:
         means, stds = utils.load_normalization(norm_filename)
     else:
         means = stds = None
 
     dataset = utils.process_dataset(dataset, vocab_table, utils.SOS, utils.EOS,
-        means, stds, min(features[0].shape[0], batch_size), 1, is_infer=True)
+                                    means, stds, 1, 1, is_infer=True)
     return dataset
+
 
 def to_text(vocab_list, sample_ids):
     sym_list = [vocab_list[x] for x in sample_ids] + [utils.EOS]
     return args.delimiter.join(sym_list[:sym_list.index(utils.EOS)])
 
+
 def main(args):
     config = tf.estimator.RunConfig(model_dir=args.model_dir)
     hparams = utils.create_hparams(args)
-
     hparams.decoder.set_hparam('beam_width', args.beam_width)
 
     vocab_list = utils.load_vocab(args.vocab)
-    vocab_list_orig = vocab_list
     binf2phone_np = None
-    binf2phone = None
-    mapping = None
     if hparams.decoder.binary_outputs:
         if args.mapping is not None:
             vocab_list, mapping = utils.get_mapping(args.mapping, args.vocab)
@@ -101,31 +85,23 @@ def main(args):
         binf2phone = utils.load_binf2phone(args.binf_map, vocab_list)
         binf2phone_np = binf2phone.values
 
-    def model_fn(features, labels,
-        mode, config, params):
+    def model_fn(features, labels, mode, config, params):
         return las_model_fn(features, labels, mode, config, params,
-            binf2phone=binf2phone_np)
+                            binf2phone=binf2phone_np)
 
     model = tf.estimator.Estimator(
         model_fn=model_fn,
         config=config,
         params=hparams)
 
-    phone_pred_key = 'sample_ids_phones_binf' if args.use_phones_from_binf else 'sample_ids'
-    predict_keys=[phone_pred_key, 'embedding', 'alignment']
-    if args.use_phones_from_binf:
-        predict_keys.append('logits_binf')
-        predict_keys.append('alignment_binf')
-
     audio, _ = librosa.load(args.waveform, sr=SAMPLE_RATE, mono=True)
     features = [calculate_acoustic_features(args, audio)]
 
     predictions = model.predict(
-        input_fn=lambda: input_fn(features, args.vocab, args.norm,
-            num_channels=features[0].shape[-1], batch_size=args.batch_size),
-        predict_keys=predict_keys)
+        input_fn=lambda: input_fn(features, args.vocab, args.norm))
     predictions = list(predictions)
     for p in predictions:
+        phone_pred_key = next(k for k in p.keys() if k.startswith('sample_ids'))
         beams = p[phone_pred_key].T
         if len(beams.shape) > 1:
             i = beams[0]
@@ -135,7 +111,13 @@ def main(args):
         i = i[:i.index(utils.EOS_ID)]
         text = to_text(vocab_list, i)
         text = text.split(args.delimiter)
+        for k in p.keys():
+            print(f'{k}: {p[k].shape}')
         print(text)
+    if args.output_file:
+        dump(predictions, args.output_file)
+        print(f'Predictions are saved to {args.output_file}')
+
 
 if __name__ == '__main__':
     tf.logging.set_verbosity(tf.logging.INFO)

--- a/transcribe_audio_file.py
+++ b/transcribe_audio_file.py
@@ -87,7 +87,7 @@ def main(args):
 
     def model_fn(features, labels, mode, config, params):
         return las_model_fn(features, labels, mode, config, params,
-                            binf2phone=binf2phone_np)
+                            binf2phone=binf2phone_np, transparent_projection=args.use_phones_from_binf)
 
     model = tf.estimator.Estimator(
         model_fn=model_fn,

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -1,15 +1,18 @@
 import tensorflow as tf
 import os
-import tensorflow.contrib as tf_contrib
-import numpy as np
 from tensor2tensor.data_generators.speech_recognition import SpeechRecognitionProblem
 from tensor2tensor.models.transformer import transformer_librispeech_tpu
 import utils
 
 __all__ = [
     'input_fn',
-    'input_fn_t2t'
+    'input_fn_t2t',
+    'process_dataset',
+    'read_dataset',
+    'process_dataset_t2t_format',
+    'read_dataset_t2t_format'
 ]
+
 
 def read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_symbols, t2t_problem_name,
     features_hparams_override=''):
@@ -25,6 +28,7 @@ def read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames, max_
     speech_params.max_target_seq_length = max_symbols
     dataset = problem.dataset(mode, data_dir=data_dir, num_threads=num_parallel_calls, hparams=speech_params)
     return dataset
+
 
 def process_dataset_t2t_format(dataset, sos_id, eos_id,
     batch_size=8, num_epochs=1, num_parallel_calls=32, is_infer=False,
@@ -113,6 +117,7 @@ def process_dataset_t2t_format(dataset, sos_id, eos_id,
 
     return dataset
 
+
 def input_fn_t2t(data_dir, mode, hparams, t2t_problem_name, batch_size=8, num_epochs=1,
     num_parallel_calls=32, max_frames=-1, max_symbols=-1, take=0, features_hparams_override=''):
     dataset = read_dataset_t2t_format(data_dir, num_parallel_calls, mode, max_frames,
@@ -128,6 +133,7 @@ def input_fn_t2t(data_dir, mode, hparams, t2t_problem_name, batch_size=8, num_ep
         dataset = dataset.take(take)
 
     return dataset
+
 
 def read_dataset(filename, num_channels=39):
     """Read data from tfrecord file."""
@@ -155,8 +161,8 @@ def read_dataset(filename, num_channels=39):
 
 
 def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
-    batch_size=8, num_epochs=1, num_parallel_calls=32, is_infer=False,
-    max_frames=-1, max_symbols=-1):
+                    batch_size=8, num_epochs=1, num_parallel_calls=32, is_infer=False,
+                    max_frames=-1, max_symbols=-1):
 
     try:
         use_labels = len(dataset.output_classes) == 2
@@ -275,6 +281,7 @@ def process_dataset(dataset, vocab_table, sos, eos, means=None, stds=None,
             drop_remainder=True)
 
     return dataset
+
 
 def input_fn(dataset_filename, vocab_filename, norm_filename=None, num_channels=39, batch_size=8, num_epochs=1,
     num_parallel_calls=32, max_frames=-1, max_symbols=-1, take=0, is_infer=False):


### PR DESCRIPTION
Standard setup: train on phones targets through binary features proxy (`--binary_outputs --output_ipa --binf_projection`).
Binary features to phones mapping is done in projection layer. As a result decoder outputs posteriograms for phones and not for indicators. This fix adds a new extension of BasicDecoder that uses projection layer to compute inputs for decoder, but not for outputs. Projection layer becomes "transparent". As a result model can output logits for indicators.

Also in this PR: security fix for bleach and minor improvements in transcription script.